### PR TITLE
Allow to run a drakefile with --unstable

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -12,12 +12,14 @@ export {
   readFile,
   sh,
   shCapture,
-  ShCaptureOpts,
-  ShOpts,
-  ShOutput,
   updateFile,
   vers,
   writeFile,
+} from "./lib/utils.ts";
+export type {
+  ShCaptureOpts,
+  ShOpts,
+  ShOutput,
 } from "./lib/utils.ts";
 
 import { env, Env } from "./lib/env.ts";


### PR DESCRIPTION
When running
```sh
deno run -A --unstable Drakefile.ts
```
I get:
```
error: TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
  ShCaptureOpts,
  ~~~~~~~~~~~~~
    at https://grrz5kxewsqlobygatm2oqna2abhovdj7l3h47umwp5mahtp2nya.arweave.net/NGOequS0oLcHBgTZp0Gg0AJ3VGn69n5-jLP6wB5v03A/mod.ts:15:3

TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
  ShOpts,
  ~~~~~~
    at https://grrz5kxewsqlobygatm2oqna2abhovdj7l3h47umwp5mahtp2nya.arweave.net/NGOequS0oLcHBgTZp0Gg0AJ3VGn69n5-jLP6wB5v03A/mod.ts:16:3

TS1205 [ERROR]: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
  ShOutput,
  ~~~~~~~~
    at https://grrz5kxewsqlobygatm2oqna2abhovdj7l3h47umwp5mahtp2nya.arweave.net/NGOequS0oLcHBgTZp0Gg0AJ3VGn69n5-jLP6wB5v03A/mod.ts:17:3

Found 3 errors.
```