### PR TITLE
Added an option for logging tasks for Github Actions

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -22,6 +22,7 @@ export class Env {
         "--abort-exits": false,
         "--always-make": false,
         "--dry-run": false,
+        "--github-actions": false,
         "--help": false,
         "--list-all": false,
         "--list-tasks": false,
@@ -38,6 +39,7 @@ export class Env {
       case "--always-make":
       case "--debug":
       case "--dry-run":
+      case "--github-actions":
       case "--help":
       case "--list-all":
       case "--list-tasks":
@@ -130,6 +132,7 @@ export class Env {
         "-D": "--debug",
         "-d": "--directory",
         "-n": "--dry-run",
+        "-g": "--github-actions",
         "-h": "--help",
         "-l": "--list-tasks",
         "-L": "--list-all",
@@ -141,6 +144,7 @@ export class Env {
       switch (arg) {
         case "--always-make":
         case "--debug":
+        case "--github-actions":
         case "--dry-run":
         case "--help":
         case "--list-tasks":

--- a/lib/help.ts
+++ b/lib/help.ts
@@ -25,6 +25,7 @@ OPTIONS
   -a, --always-make     Unconditionally execute tasks.
   --cache FILE          Set Drake cache file path to FILE.
   -d, --directory DIR   Change to directory DIR before running drakefile.
+  -g, --github-actions  logs expandable targets for Github Actions
   -D, --debug           Write debug information to stderr.
   -h, --help            Display this help message.
   -l, -L, --list-tasks  List tasks (-L for hidden tasks and prerequisites).

--- a/lib/tasks.ts
+++ b/lib/tasks.ts
@@ -413,7 +413,7 @@ export class TaskRegistry extends Map<string, Task> {
     let msg = "";
     let startTime: number = 0;
     if (names.length === 1) {
-      msg = `${colors.green(colors.bold(`${names[0]}:`))}`;
+      msg = `${colors.green(colors.bold(`${names[0]}` + (env("--github-actions") ? "" : ":")))}`;
     } else {
       msg = colors.green(colors.bold(`execute ${names.length} tasks:`));
       log(`${msg} started`);
@@ -432,7 +432,11 @@ export class TaskRegistry extends Map<string, Task> {
         continue;
       }
       if (names.length === 1) {
-        log(`${msg} started`);
+        if (env("--github-actions")) {
+          log(`::group::${msg}`)
+        } else {
+          log(`${msg} started`);
+        }
         startTime = new Date().getTime();
       }
       if (task.action.constructor.name === "AsyncFunction") {
@@ -447,7 +451,11 @@ export class TaskRegistry extends Map<string, Task> {
       task.updateCache();
     }
     if (startTime) {
-      log(`${msg} finished (${new Date().getTime() - startTime}ms)`);
+      if (env("--github-actions")) {
+        log("::endgroup::");
+      } else {
+        log(`${msg} finished (${new Date().getTime() - startTime}ms)`);
+      }
     }
   }
 }


### PR DESCRIPTION
Instead of logging tasks like 'start task1' and 'end task1', output will now be like '::group::task1' and '::endgroup::' when the -g flag is given. This should resolve #9 .